### PR TITLE
Handle rate limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,6 +1640,11 @@
         }
       }
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "axios": "^0.19.2",
+        "delay": "^4.3.0",
         "form-data": "^3.0.0",
         "qs": "^6.9.3"
     },

--- a/samples.md
+++ b/samples.md
@@ -17,7 +17,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi().list()
 await rc.revoke()
 ```
@@ -43,7 +47,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi().oauth().revoke().post(revokeTokenRequest)
 await rc.revoke()
 ```
@@ -69,7 +77,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi().oauth().token().post(getTokenRequest)
 await rc.revoke()
 ```
@@ -95,7 +107,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).get()
 await rc.revoke()
 ```
@@ -122,7 +138,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).get()
 await rc.revoke()
 ```
@@ -150,7 +170,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).activeCalls().get(listCompanyActiveCallsParameters)
 await rc.revoke()
 ```
@@ -178,7 +202,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).answeringRule().post(companyAnsweringRuleRequest)
 await rc.revoke()
 ```
@@ -206,7 +234,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).answeringRule().list(listCompanyAnsweringRulesParameters)
 await rc.revoke()
 ```
@@ -234,7 +266,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).answeringRule(ruleId).get()
 await rc.revoke()
 ```
@@ -262,7 +298,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).answeringRule(ruleId).put(companyAnsweringRuleUpdate)
 await rc.revoke()
 ```
@@ -290,7 +330,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).answeringRule(ruleId).delete()
 await rc.revoke()
 ```
@@ -318,7 +362,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).businessAddress().get()
 await rc.revoke()
 ```
@@ -346,7 +394,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).businessAddress().put(modifyAccountBusinessAddressRequest)
 await rc.revoke()
 ```
@@ -374,7 +426,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).businessHours().get()
 await rc.revoke()
 ```
@@ -402,7 +458,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).businessHours().put(companyBusinessHoursUpdateRequest)
 await rc.revoke()
 ```
@@ -430,7 +490,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callLog().list(readCompanyCallLogParameters)
 await rc.revoke()
 ```
@@ -458,7 +522,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callLogSync().get(syncAccountCallLogParameters)
 await rc.revoke()
 ```
@@ -486,7 +554,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callLog(callRecordId).get(readCompanyCallRecordParameters)
 await rc.revoke()
 ```
@@ -514,7 +586,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups().post(createCallMonitoringGroupRequest)
 await rc.revoke()
 ```
@@ -542,7 +618,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups().get(listCallMonitoringGroupsParameters)
 await rc.revoke()
 ```
@@ -570,7 +650,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups(groupId).put(createCallMonitoringGroupRequest)
 await rc.revoke()
 ```
@@ -598,7 +682,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups(groupId).delete()
 await rc.revoke()
 ```
@@ -626,7 +714,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups(groupId).bulkAssign().post(callMonitoringBulkAssign)
 await rc.revoke()
 ```
@@ -654,7 +746,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callMonitoringGroups(groupId).members().get(listCallMonitoringGroupMembersParameters)
 await rc.revoke()
 ```
@@ -682,7 +778,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callQueues().get(listCallQueuesParameters)
 await rc.revoke()
 ```
@@ -710,7 +810,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callQueues(groupId).bulkAssign().post(callQueueBulkAssignResource)
 await rc.revoke()
 ```
@@ -738,7 +842,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callQueues(groupId).members().get(listCallQueueMembersParameters)
 await rc.revoke()
 ```
@@ -766,7 +874,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().get()
 await rc.revoke()
 ```
@@ -794,7 +906,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().put(callRecordingSettingsResource)
 await rc.revoke()
 ```
@@ -822,7 +938,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().bulkAssign().post(bulkAccountCallRecordingsResource)
 await rc.revoke()
 ```
@@ -850,7 +970,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().customGreetings().get(listCallRecordingCustomGreetingsParameters)
 await rc.revoke()
 ```
@@ -878,7 +1002,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().customGreetings(greetingId).delete()
 await rc.revoke()
 ```
@@ -906,7 +1034,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).callRecording().extensions().get()
 await rc.revoke()
 ```
@@ -934,7 +1066,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).customFields().post(customFieldCreateRequest)
 await rc.revoke()
 ```
@@ -962,7 +1098,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).customFields().get()
 await rc.revoke()
 ```
@@ -990,7 +1130,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).customFields(fieldId).put(customFieldUpdateRequest)
 await rc.revoke()
 ```
@@ -1018,7 +1162,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).customFields(fieldId).delete()
 await rc.revoke()
 ```
@@ -1046,7 +1194,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).department().bulkAssign().post(departmentBulkAssignResource)
 await rc.revoke()
 ```
@@ -1074,7 +1226,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).department(departmentId).members().get(listDepartmentMembersParameters)
 await rc.revoke()
 ```
@@ -1102,7 +1258,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).device(deviceId).get(readDeviceParameters)
 await rc.revoke()
 ```
@@ -1130,7 +1290,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).device(deviceId).put(accountDeviceUpdate, updateDeviceParameters)
 await rc.revoke()
 ```
@@ -1159,7 +1323,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).directory().entries().list(listDirectoryEntriesParameters)
 await rc.revoke()
 ```
@@ -1187,7 +1355,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).directory().entries().search().post(searchDirectoryEntriesRequest)
 await rc.revoke()
 ```
@@ -1215,7 +1387,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).directory().entries(entryId).get()
 await rc.revoke()
 ```
@@ -1243,7 +1419,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).directory().federation().get()
 await rc.revoke()
 ```
@@ -1271,7 +1451,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().devices().get(listDevicesAutomaticLocationUpdatesParameters)
 await rc.revoke()
 ```
@@ -1299,7 +1483,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().devices().bulkAssign().post(assignMultipleDevicesAutomaticLocationUpdates)
 await rc.revoke()
 ```
@@ -1327,7 +1515,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().networks().list()
 await rc.revoke()
 ```
@@ -1355,7 +1547,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().networks().post(createNetworkRequest)
 await rc.revoke()
 ```
@@ -1383,7 +1579,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().networks(networkId).get()
 await rc.revoke()
 ```
@@ -1411,7 +1611,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().networks(networkId).put(updateNetworkRequest)
 await rc.revoke()
 ```
@@ -1439,7 +1643,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().networks(networkId).delete()
 await rc.revoke()
 ```
@@ -1467,7 +1675,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switches().list(listAccountSwitchesParameters)
 await rc.revoke()
 ```
@@ -1495,7 +1707,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switches().post(createSwitchInfo)
 await rc.revoke()
 ```
@@ -1523,7 +1739,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switchesBulkCreate().post(createMultipleSwitchesRequest)
 await rc.revoke()
 ```
@@ -1551,7 +1771,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switchesBulkUpdate().post(updateMultipleSwitchesRequest)
 await rc.revoke()
 ```
@@ -1579,7 +1803,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switchesBulkValidate().post(validateMultipleSwitchesRequest)
 await rc.revoke()
 ```
@@ -1607,7 +1835,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switches(switchId).get()
 await rc.revoke()
 ```
@@ -1635,7 +1867,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switches(switchId).put(updateSwitchInfo)
 await rc.revoke()
 ```
@@ -1663,7 +1899,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().switches(switchId).delete()
 await rc.revoke()
 ```
@@ -1691,7 +1931,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().tasks(taskId).get()
 await rc.revoke()
 ```
@@ -1719,7 +1963,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().users().get(listAutomaticLocationUpdatesUsersParameters)
 await rc.revoke()
 ```
@@ -1747,7 +1995,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().users().bulkAssign().post(bulkAssignAutomaticaLocationUpdatesUsers)
 await rc.revoke()
 ```
@@ -1775,7 +2027,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPoints().list(listWirelessPointsParameters)
 await rc.revoke()
 ```
@@ -1803,7 +2059,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPoints().post(createWirelessPoint)
 await rc.revoke()
 ```
@@ -1831,7 +2091,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPointsBulkCreate().post(createMultipleWirelessPointsRequest)
 await rc.revoke()
 ```
@@ -1859,7 +2123,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPointsBulkUpdate().post(updateMultipleWirelessPointsRequest)
 await rc.revoke()
 ```
@@ -1887,7 +2155,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPointsBulkValidate().post(validateMultipleWirelessPointsRequest)
 await rc.revoke()
 ```
@@ -1915,7 +2187,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPoints(pointId).get()
 await rc.revoke()
 ```
@@ -1943,7 +2219,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPoints(pointId).put(updateWirelessPoint)
 await rc.revoke()
 ```
@@ -1971,7 +2251,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyAddressAutoUpdate().wirelessPoints(pointId).delete()
 await rc.revoke()
 ```
@@ -1999,7 +2283,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyLocations().post(emergencyLocationInfoRequest)
 await rc.revoke()
 ```
@@ -2027,7 +2315,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyLocations().list(listEmergencyLocationsParameters)
 await rc.revoke()
 ```
@@ -2055,7 +2347,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyLocations(locationId).get()
 await rc.revoke()
 ```
@@ -2083,7 +2379,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).emergencyLocations(locationId).put(emergencyLocationInfoRequest)
 await rc.revoke()
 ```
@@ -2111,7 +2411,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension().list(listExtensionsParameters)
 await rc.revoke()
 ```
@@ -2139,7 +2443,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension().post(extensionCreationRequest)
 await rc.revoke()
 ```
@@ -2167,7 +2475,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).get()
 await rc.revoke()
 ```
@@ -2196,7 +2508,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).put(extensionUpdateRequest)
 await rc.revoke()
 ```
@@ -2225,7 +2541,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).delete(deleteExtensionParameters)
 await rc.revoke()
 ```
@@ -2254,7 +2574,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).activeCalls().get(listExtensionActiveCallsParameters)
 await rc.revoke()
 ```
@@ -2283,7 +2607,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBookSync().get(syncAddressBookParameters)
 await rc.revoke()
 ```
@@ -2312,7 +2640,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBook().contact().list(listContactsParameters)
 await rc.revoke()
 ```
@@ -2341,7 +2673,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBook().contact().post(personalContactRequest, createContactParameters)
 await rc.revoke()
 ```
@@ -2371,7 +2707,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBook().contact(contactId).get()
 await rc.revoke()
 ```
@@ -2400,7 +2740,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBook().contact(contactId).put(personalContactRequest, updateContactParameters)
 await rc.revoke()
 ```
@@ -2430,7 +2774,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).addressBook().contact(contactId).delete()
 await rc.revoke()
 ```
@@ -2459,7 +2807,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).answeringRule().list(listAnsweringRulesParameters)
 await rc.revoke()
 ```
@@ -2488,7 +2840,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).answeringRule().post(createAnsweringRuleRequest)
 await rc.revoke()
 ```
@@ -2517,7 +2873,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).answeringRule(ruleId).get(readAnsweringRuleParameters)
 await rc.revoke()
 ```
@@ -2546,7 +2906,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).answeringRule(ruleId).put(updateAnsweringRuleRequest)
 await rc.revoke()
 ```
@@ -2575,7 +2939,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).answeringRule(ruleId).delete()
 await rc.revoke()
 ```
@@ -2604,7 +2972,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).authzProfile().get()
 await rc.revoke()
 ```
@@ -2633,7 +3005,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).authzProfile().check().get(checkUserPermissionParameters)
 await rc.revoke()
 ```
@@ -2662,7 +3038,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).businessHours().get()
 await rc.revoke()
 ```
@@ -2691,7 +3071,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).businessHours().put(userBusinessHoursUpdateRequest)
 await rc.revoke()
 ```
@@ -2720,7 +3104,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callLog().list(readUserCallLogParameters)
 await rc.revoke()
 ```
@@ -2749,7 +3137,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callLog().delete(deleteUserCallLogParameters)
 await rc.revoke()
 ```
@@ -2778,7 +3170,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callLogSync().get(syncUserCallLogParameters)
 await rc.revoke()
 ```
@@ -2807,7 +3203,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callLog(callRecordId).get(readUserCallRecordParameters)
 await rc.revoke()
 ```
@@ -2836,7 +3236,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callQueues().put(userCallQueues)
 await rc.revoke()
 ```
@@ -2865,7 +3269,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().get()
 await rc.revoke()
 ```
@@ -2894,7 +3302,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().put(callerBlockingSettingsUpdate)
 await rc.revoke()
 ```
@@ -2923,7 +3335,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().phoneNumbers().list(listBlockedAllowedNumbersParameters)
 await rc.revoke()
 ```
@@ -2952,7 +3368,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().phoneNumbers().post(addBlockedAllowedPhoneNumber)
 await rc.revoke()
 ```
@@ -2981,7 +3401,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().phoneNumbers(blockedNumberId).get()
 await rc.revoke()
 ```
@@ -3010,7 +3434,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().phoneNumbers(blockedNumberId).delete()
 await rc.revoke()
 ```
@@ -3039,7 +3467,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerBlocking().phoneNumbers(blockedNumberId).put(addBlockedAllowedPhoneNumber)
 await rc.revoke()
 ```
@@ -3068,7 +3500,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerId().get()
 await rc.revoke()
 ```
@@ -3097,7 +3533,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).callerId().put(extensionCallerIdInfo)
 await rc.revoke()
 ```
@@ -3126,7 +3566,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).companyPager().post(createInternalTextMessageRequest)
 await rc.revoke()
 ```
@@ -3155,7 +3599,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).conferencing().get(readConferencingSettingsParameters)
 await rc.revoke()
 ```
@@ -3184,7 +3632,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).conferencing().put(updateConferencingInfoRequest)
 await rc.revoke()
 ```
@@ -3213,7 +3665,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).device().get(listExtensionDevicesParameters)
 await rc.revoke()
 ```
@@ -3242,7 +3698,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).favorite().get()
 await rc.revoke()
 ```
@@ -3271,7 +3731,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).favorite().put(favoriteCollection)
 await rc.revoke()
 ```
@@ -3300,7 +3764,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).fax().post(createFaxMessageRequest)
 await rc.revoke()
 ```
@@ -3329,7 +3797,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).features().get(readUserFeaturesParameters)
 await rc.revoke()
 ```
@@ -3358,7 +3830,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).forwardingNumber().list(listForwardingNumbersParameters)
 await rc.revoke()
 ```
@@ -3387,7 +3863,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).forwardingNumber().post(createForwardingNumberRequest)
 await rc.revoke()
 ```
@@ -3416,7 +3896,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).forwardingNumber(forwardingNumberId).get()
 await rc.revoke()
 ```
@@ -3445,7 +3929,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).forwardingNumber(forwardingNumberId).put(updateForwardingNumberRequest)
 await rc.revoke()
 ```
@@ -3474,7 +3962,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).forwardingNumber(forwardingNumberId).delete()
 await rc.revoke()
 ```
@@ -3503,7 +3995,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).grant().get(listExtensionGrantsParameters)
 await rc.revoke()
 ```
@@ -3532,7 +4028,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).greeting().post(createCustomUserGreetingRequest)
 await rc.revoke()
 ```
@@ -3561,7 +4061,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).greeting(greetingId).get()
 await rc.revoke()
 ```
@@ -3590,7 +4094,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting().list()
 await rc.revoke()
 ```
@@ -3619,7 +4127,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting().post(meetingRequestResource)
 await rc.revoke()
 ```
@@ -3648,7 +4160,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meetingRecordings().get(listUserMeetingRecordingsParameters)
 await rc.revoke()
 ```
@@ -3677,7 +4193,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting().serviceInfo().get()
 await rc.revoke()
 ```
@@ -3706,7 +4226,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting().serviceInfo().patch(meetingServiceInfoRequest)
 await rc.revoke()
 ```
@@ -3735,7 +4259,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting(meetingId).get()
 await rc.revoke()
 ```
@@ -3764,7 +4292,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting(meetingId).put(meetingRequestResource)
 await rc.revoke()
 ```
@@ -3793,7 +4325,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting(meetingId).delete()
 await rc.revoke()
 ```
@@ -3822,7 +4358,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meeting(meetingId).end().post()
 await rc.revoke()
 ```
@@ -3851,7 +4391,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meetingsConfiguration().assistants().get()
 await rc.revoke()
 ```
@@ -3880,7 +4424,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).meetingsConfiguration().assisted().get()
 await rc.revoke()
 ```
@@ -3909,7 +4457,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageStore().list(listMessagesParameters)
 await rc.revoke()
 ```
@@ -3938,7 +4490,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageStore(messageId).get()
 await rc.revoke()
 ```
@@ -3967,7 +4523,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageStore(messageId).put(updateMessageRequest, updateMessageParameters)
 await rc.revoke()
 ```
@@ -3997,7 +4557,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageStore(messageId).delete(deleteMessageParameters)
 await rc.revoke()
 ```
@@ -4026,7 +4590,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageStore(messageId).content(attachmentId).get(readMessageContentParameters)
 await rc.revoke()
 ```
@@ -4059,7 +4627,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).messageSync().get(syncMessagesParameters)
 await rc.revoke()
 ```
@@ -4088,7 +4660,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).mms().post(createMmsMessage)
 await rc.revoke()
 ```
@@ -4117,7 +4693,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).notificationSettings().get()
 await rc.revoke()
 ```
@@ -4146,7 +4726,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).notificationSettings().put(notificationSettingsUpdateRequest)
 await rc.revoke()
 ```
@@ -4175,7 +4759,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).phoneNumber().get(listExtensionPhoneNumbersParameters)
 await rc.revoke()
 ```
@@ -4204,7 +4792,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).presence().get(readUserPresenceStatusParameters)
 await rc.revoke()
 ```
@@ -4233,7 +4825,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).presence().put(presenceInfoResource)
 await rc.revoke()
 ```
@@ -4262,7 +4858,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).profileImage().list()
 await rc.revoke()
 ```
@@ -4295,7 +4895,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).profileImage().post(createUserProfileImageRequest)
 await rc.revoke()
 ```
@@ -4324,7 +4928,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).profileImage().put(updateUserProfileImageRequest)
 await rc.revoke()
 ```
@@ -4353,7 +4961,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).profileImage(scaleSize).get()
 await rc.revoke()
 ```
@@ -4386,7 +4998,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringOut().post(makeRingOutRequest)
 await rc.revoke()
 ```
@@ -4415,7 +5031,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringOut(ringoutId).get()
 await rc.revoke()
 ```
@@ -4444,7 +5064,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringOut(ringoutId).delete()
 await rc.revoke()
 ```
@@ -4473,7 +5097,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringout().post(makeRingOutRequest)
 await rc.revoke()
 ```
@@ -4502,7 +5130,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringout(ringoutId).get()
 await rc.revoke()
 ```
@@ -4531,7 +5163,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).ringout(ringoutId).delete()
 await rc.revoke()
 ```
@@ -4560,7 +5196,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).sms().post(createSmsMessage)
 await rc.revoke()
 ```
@@ -4589,7 +5229,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).unifiedPresence().get()
 await rc.revoke()
 ```
@@ -4618,7 +5262,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).unifiedPresence().patch(updateUnifiedPresence)
 await rc.revoke()
 ```
@@ -4647,7 +5295,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).videoConfiguration().get()
 await rc.revoke()
 ```
@@ -4676,7 +5328,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).extension(extensionId).videoConfiguration().put(userVideoConfiguration)
 await rc.revoke()
 ```
@@ -4705,7 +5361,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).greeting().post(createCompanyGreetingRequest)
 await rc.revoke()
 ```
@@ -4733,7 +5393,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrMenus().post(ivrMenuInfo)
 await rc.revoke()
 ```
@@ -4761,7 +5425,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrMenus(ivrMenuId).get()
 await rc.revoke()
 ```
@@ -4789,7 +5457,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrMenus(ivrMenuId).put(ivrMenuInfo)
 await rc.revoke()
 ```
@@ -4817,7 +5489,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts().post(createIvrPromptRequest)
 await rc.revoke()
 ```
@@ -4845,7 +5521,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts().list()
 await rc.revoke()
 ```
@@ -4873,7 +5553,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts(promptId).get()
 await rc.revoke()
 ```
@@ -4901,7 +5585,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts(promptId).delete()
 await rc.revoke()
 ```
@@ -4929,7 +5617,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts(promptId).put(updateIvrPromptRequest)
 await rc.revoke()
 ```
@@ -4957,7 +5649,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).ivrPrompts(promptId).content().get()
 await rc.revoke()
 ```
@@ -4989,7 +5685,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).meetingRecordings().get(listAccountMeetingRecordingsParameters)
 await rc.revoke()
 ```
@@ -5017,7 +5717,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreConfiguration().get()
 await rc.revoke()
 ```
@@ -5045,7 +5749,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreConfiguration().put(messageStoreConfiguration)
 await rc.revoke()
 ```
@@ -5073,7 +5781,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreReport().post(createMessageStoreReportRequest)
 await rc.revoke()
 ```
@@ -5101,7 +5813,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreReport(taskId).get()
 await rc.revoke()
 ```
@@ -5129,7 +5845,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreReport(taskId).archive().list()
 await rc.revoke()
 ```
@@ -5157,7 +5877,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).messageStoreReport(taskId).archive(archiveId).get()
 await rc.revoke()
 ```
@@ -5185,7 +5909,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).pagingOnlyGroups(pagingOnlyGroupId).bulkAssign().post(editPagingGroupRequest)
 await rc.revoke()
 ```
@@ -5213,7 +5941,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).pagingOnlyGroups(pagingOnlyGroupId).devices().get(listPagingGroupDevicesParameters)
 await rc.revoke()
 ```
@@ -5241,7 +5973,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).pagingOnlyGroups(pagingOnlyGroupId).users().get(listPagingGroupUsersParameters)
 await rc.revoke()
 ```
@@ -5269,7 +6005,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).phoneNumber().list(listAccountPhoneNumbersParameters)
 await rc.revoke()
 ```
@@ -5297,7 +6037,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).phoneNumber(phoneNumberId).get()
 await rc.revoke()
 ```
@@ -5325,7 +6069,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).presence().get(readAccountPresenceParameters)
 await rc.revoke()
 ```
@@ -5353,7 +6101,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).recording(recordingId).get()
 await rc.revoke()
 ```
@@ -5381,7 +6133,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).recording(recordingId).content().get()
 await rc.revoke()
 ```
@@ -5413,7 +6169,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).serviceInfo().get()
 await rc.revoke()
 ```
@@ -5441,7 +6201,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().callOut().post(makeCallOutRequest)
 await rc.revoke()
 ```
@@ -5469,7 +6233,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).get(readCallSessionStatusParameters)
 await rc.revoke()
 ```
@@ -5497,7 +6265,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).delete()
 await rc.revoke()
 ```
@@ -5525,7 +6297,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).get()
 await rc.revoke()
 ```
@@ -5553,7 +6329,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).patch(partyUpdateRequest)
 await rc.revoke()
 ```
@@ -5581,7 +6361,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).answer().post(answerTarget)
 await rc.revoke()
 ```
@@ -5609,7 +6393,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).flip().post(callPartyFlip)
 await rc.revoke()
 ```
@@ -5637,7 +6425,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).forward().post(forwardTarget)
 await rc.revoke()
 ```
@@ -5665,7 +6457,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).hold().post()
 await rc.revoke()
 ```
@@ -5693,7 +6489,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).ignore().post(ignoreRequestBody)
 await rc.revoke()
 ```
@@ -5721,7 +6521,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).park().post()
 await rc.revoke()
 ```
@@ -5749,7 +6553,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).pickup().post(pickupTarget)
 await rc.revoke()
 ```
@@ -5777,7 +6585,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).recordings().post()
 await rc.revoke()
 ```
@@ -5805,7 +6617,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).recordings(recordingId).patch(callRecordingUpdate, pauseResumeCallRecordingParameters)
 await rc.revoke()
 ```
@@ -5834,7 +6650,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).reject().post()
 await rc.revoke()
 ```
@@ -5862,7 +6682,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).reply().post(callPartyReply)
 await rc.revoke()
 ```
@@ -5890,7 +6714,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).supervise().post(partySuperviseRequest)
 await rc.revoke()
 ```
@@ -5918,7 +6746,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).transfer().post(transferTarget)
 await rc.revoke()
 ```
@@ -5946,7 +6778,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).parties(partyId).unhold().post()
 await rc.revoke()
 ```
@@ -5974,7 +6810,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).telephony().sessions(telephonySessionId).supervise().post(superviseCallSessionRequest)
 await rc.revoke()
 ```
@@ -6002,7 +6842,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).templates().list(listUserTemplatesParameters)
 await rc.revoke()
 ```
@@ -6030,7 +6874,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).account(accountId).templates(templateId).get()
 await rc.revoke()
 ```
@@ -6058,7 +6906,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).clientInfo().sipProvision().post(createSipRegistrationRequest)
 await rc.revoke()
 ```
@@ -6085,7 +6937,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().country().list(listCountriesParameters)
 await rc.revoke()
 ```
@@ -6112,7 +6968,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().country(countryId).get()
 await rc.revoke()
 ```
@@ -6139,7 +6999,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().faxCoverPage().get(listFaxCoverPagesParameters)
 await rc.revoke()
 ```
@@ -6166,7 +7030,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().greeting().list(listStandardGreetingsParameters)
 await rc.revoke()
 ```
@@ -6193,7 +7061,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().greeting(greetingId).get()
 await rc.revoke()
 ```
@@ -6220,7 +7092,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().language().list()
 await rc.revoke()
 ```
@@ -6247,7 +7123,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().language(languageId).get()
 await rc.revoke()
 ```
@@ -6274,7 +7154,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().location().get(listLocationsParameters)
 await rc.revoke()
 ```
@@ -6301,7 +7185,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().state().list(listStatesParameters)
 await rc.revoke()
 ```
@@ -6328,7 +7216,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().state(stateId).get()
 await rc.revoke()
 ```
@@ -6355,7 +7247,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().timezone().list(listTimezonesParameters)
 await rc.revoke()
 ```
@@ -6382,7 +7278,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).dictionary().timezone(timezoneId).get(readTimezoneParameters)
 await rc.revoke()
 ```
@@ -6409,7 +7309,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().cards().post(glipMessageAttachmentInfoRequest, createGlipCardParameters)
 await rc.revoke()
 ```
@@ -6437,7 +7341,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().cards(cardId).get()
 await rc.revoke()
 ```
@@ -6464,7 +7372,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().cards(cardId).put(glipMessageAttachmentInfoRequest)
 await rc.revoke()
 ```
@@ -6491,7 +7403,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().cards(cardId).delete()
 await rc.revoke()
 ```
@@ -6518,7 +7434,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats().list(listGlipChatsParameters)
 await rc.revoke()
 ```
@@ -6545,7 +7465,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).get()
 await rc.revoke()
 ```
@@ -6572,7 +7496,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).favorite().post()
 await rc.revoke()
 ```
@@ -6599,7 +7527,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).notes().post(glipNoteCreate)
 await rc.revoke()
 ```
@@ -6626,7 +7558,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).notes().get(listChatNotesParameters)
 await rc.revoke()
 ```
@@ -6653,7 +7589,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).posts().list(readGlipPostsParameters)
 await rc.revoke()
 ```
@@ -6680,7 +7620,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).posts().post(glipPostPostBody)
 await rc.revoke()
 ```
@@ -6707,7 +7651,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).posts(postId).get()
 await rc.revoke()
 ```
@@ -6734,7 +7682,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).posts(postId).patch(glipPatchPostBody)
 await rc.revoke()
 ```
@@ -6761,7 +7713,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).posts(postId).delete()
 await rc.revoke()
 ```
@@ -6788,7 +7744,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).read().post()
 await rc.revoke()
 ```
@@ -6815,7 +7775,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).tasks().get(listChatTasksParameters)
 await rc.revoke()
 ```
@@ -6842,7 +7806,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).tasks().post(glipCreateTask)
 await rc.revoke()
 ```
@@ -6869,7 +7837,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).unfavorite().post()
 await rc.revoke()
 ```
@@ -6896,7 +7868,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().chats(chatId).unread().post()
 await rc.revoke()
 ```
@@ -6923,7 +7899,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().companies(companyId).get()
 await rc.revoke()
 ```
@@ -6950,7 +7930,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().conversations().list(listGlipConversationsParameters)
 await rc.revoke()
 ```
@@ -6977,7 +7961,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().conversations().post(createGlipConversationRequest)
 await rc.revoke()
 ```
@@ -7004,7 +7992,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().conversations(chatId).get()
 await rc.revoke()
 ```
@@ -7031,7 +8023,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().dataExport().post(createDataExportTaskRequest)
 await rc.revoke()
 ```
@@ -7058,7 +8054,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().dataExport().list(listDataExportTasksParameters)
 await rc.revoke()
 ```
@@ -7085,7 +8085,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().dataExport(taskId).get()
 await rc.revoke()
 ```
@@ -7112,7 +8116,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().dataExport(taskId).datasets(datasetId).get()
 await rc.revoke()
 ```
@@ -7143,7 +8151,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().events().list(readGlipEventsParameters)
 await rc.revoke()
 ```
@@ -7170,7 +8182,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().events().post(glipEventCreate)
 await rc.revoke()
 ```
@@ -7197,7 +8213,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().events(eventId).get()
 await rc.revoke()
 ```
@@ -7224,7 +8244,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().events(eventId).put(glipEventCreate)
 await rc.revoke()
 ```
@@ -7251,7 +8275,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().events(eventId).delete()
 await rc.revoke()
 ```
@@ -7278,7 +8306,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().everyone().get()
 await rc.revoke()
 ```
@@ -7305,7 +8337,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().everyone().patch(updateGlipEveryoneRequest)
 await rc.revoke()
 ```
@@ -7332,7 +8368,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().favorites().get(listFavoriteChatsParameters)
 await rc.revoke()
 ```
@@ -7359,7 +8399,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups().list(listGlipGroupsParameters)
 await rc.revoke()
 ```
@@ -7386,7 +8430,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups().post(glipCreateGroup)
 await rc.revoke()
 ```
@@ -7413,7 +8461,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).get()
 await rc.revoke()
 ```
@@ -7440,7 +8492,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).bulkAssign().post(editGroupRequest)
 await rc.revoke()
 ```
@@ -7467,7 +8523,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).events().post(glipEventCreate)
 await rc.revoke()
 ```
@@ -7494,7 +8554,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).events().get()
 await rc.revoke()
 ```
@@ -7521,7 +8585,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).posts().get(listGlipGroupPostsParameters)
 await rc.revoke()
 ```
@@ -7548,7 +8616,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).posts().post(glipCreatePost)
 await rc.revoke()
 ```
@@ -7575,7 +8647,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).posts(postId).text().put(string)
 await rc.revoke()
 ```
@@ -7602,7 +8678,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).webhooks().post()
 await rc.revoke()
 ```
@@ -7629,7 +8709,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().groups(groupId).webhooks().get()
 await rc.revoke()
 ```
@@ -7656,7 +8740,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).get()
 await rc.revoke()
 ```
@@ -7683,7 +8771,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).patch(glipNoteCreate)
 await rc.revoke()
 ```
@@ -7710,7 +8802,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).delete()
 await rc.revoke()
 ```
@@ -7737,7 +8833,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).lock().post()
 await rc.revoke()
 ```
@@ -7764,7 +8864,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).publish().post()
 await rc.revoke()
 ```
@@ -7791,7 +8895,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().notes(noteId).unlock().post()
 await rc.revoke()
 ```
@@ -7818,7 +8926,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().persons(personId).get()
 await rc.revoke()
 ```
@@ -7845,7 +8957,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().posts().get(listGlipPostsParameters)
 await rc.revoke()
 ```
@@ -7872,7 +8988,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().posts().post(glipCreatePost)
 await rc.revoke()
 ```
@@ -7899,7 +9019,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().preferences().get()
 await rc.revoke()
 ```
@@ -7926,7 +9050,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().recent().chats().get(listRecentChatsParameters)
 await rc.revoke()
 ```
@@ -7953,7 +9081,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().tasks(taskId).get()
 await rc.revoke()
 ```
@@ -7980,7 +9112,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().tasks(taskId).patch(glipUpdateTask)
 await rc.revoke()
 ```
@@ -8007,7 +9143,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().tasks(taskId).delete()
 await rc.revoke()
 ```
@@ -8034,7 +9174,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().tasks(taskId).complete().post(glipCompleteTask)
 await rc.revoke()
 ```
@@ -8061,7 +9205,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams().list(listGlipTeamsParameters)
 await rc.revoke()
 ```
@@ -8088,7 +9236,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams().post(glipPostTeamBody)
 await rc.revoke()
 ```
@@ -8115,7 +9267,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).get()
 await rc.revoke()
 ```
@@ -8142,7 +9298,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).patch(glipPatchTeamBody)
 await rc.revoke()
 ```
@@ -8169,7 +9329,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).delete()
 await rc.revoke()
 ```
@@ -8196,7 +9360,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).add().post(glipPostMembersListBody)
 await rc.revoke()
 ```
@@ -8223,7 +9391,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).archive().post()
 await rc.revoke()
 ```
@@ -8250,7 +9422,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).join().post()
 await rc.revoke()
 ```
@@ -8277,7 +9453,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).leave().post()
 await rc.revoke()
 ```
@@ -8304,7 +9484,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).remove().post(glipPostMembersIdsListBody)
 await rc.revoke()
 ```
@@ -8331,7 +9515,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().teams(chatId).unarchive().post()
 await rc.revoke()
 ```
@@ -8358,7 +9546,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().webhooks().list()
 await rc.revoke()
 ```
@@ -8385,7 +9577,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().webhooks(webhookId).get()
 await rc.revoke()
 ```
@@ -8412,7 +9608,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().webhooks(webhookId).delete()
 await rc.revoke()
 ```
@@ -8439,7 +9639,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().webhooks(webhookId).activate().post()
 await rc.revoke()
 ```
@@ -8466,7 +9670,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).glip().webhooks(webhookId).suspend().post()
 await rc.revoke()
 ```
@@ -8493,7 +9701,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).numberParser().parse().post(parsePhoneNumberRequest, parsePhoneNumberParameters)
 await rc.revoke()
 ```
@@ -8521,7 +9733,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).status().get()
 await rc.revoke()
 ```
@@ -8548,7 +9764,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription().list()
 await rc.revoke()
 ```
@@ -8575,7 +9795,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription().post(createSubscriptionRequest)
 await rc.revoke()
 ```
@@ -8602,7 +9826,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription(subscriptionId).get()
 await rc.revoke()
 ```
@@ -8629,7 +9857,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription(subscriptionId).put(modifySubscriptionRequest, updateSubscriptionParameters)
 await rc.revoke()
 ```
@@ -8657,7 +9889,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription(subscriptionId).delete()
 await rc.revoke()
 ```
@@ -8684,7 +9920,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.restapi(apiVersion).subscription(subscriptionId).renew().post()
 await rc.revoke()
 ```
@@ -8711,7 +9951,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).serviceProviderConfig().get()
 await rc.revoke()
 ```
@@ -8738,7 +9982,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users().list(searchViaGet2Parameters)
 await rc.revoke()
 ```
@@ -8765,7 +10013,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users().post(createUser)
 await rc.revoke()
 ```
@@ -8792,7 +10044,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users().dotSearch().post(searchRequest)
 await rc.revoke()
 ```
@@ -8819,7 +10075,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users(id).get()
 await rc.revoke()
 ```
@@ -8846,7 +10106,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users(id).put(user)
 await rc.revoke()
 ```
@@ -8873,7 +10137,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users(id).delete()
 await rc.revoke()
 ```
@@ -8900,7 +10168,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).users(id).patch(userPatch)
 await rc.revoke()
 ```
@@ -8927,7 +10199,11 @@ const rc = new RestClient({
     clientSecret: process.env.RINGCENTRAL_CLIENT_SECRET,
     server: process.env.RINGCENTRAL_SERVER_URL
 })
-await rc.authorize(username, extension, password)
+await rc.login({
+    username: process.env.RINGCENTRAL_USERNAME,
+    extension: process.env.RINGCENTRAL_EXTENSION,
+    password: process.env.RINGCENTRAL_PASSWORD
+})
 const result = await rc.scim(version).health().get()
 await rc.revoke()
 ```


### PR DESCRIPTION
This is a "dumb" handler. 

The constructor value is a (boolean | number) field for the user to set. 

If true, it will use the `rate-limit-window` header value (or in the case this header is missing, will default to 60 seconds). 

If the user specifies a number, that value is used as the delay instead. 

